### PR TITLE
Fix amount value float conversion

### DIFF
--- a/src/MT942Normalizer.php
+++ b/src/MT942Normalizer.php
@@ -186,7 +186,7 @@ final class MT942Normalizer extends MT942Formatter
         $result->setMark(!empty($details[0]['mark']) ? $details[0]['mark'] : null);
         $money = $result->getMoney();
         $money->setCurrency($details[0]['currency']);
-        $money->setAmount((float)$details[0]['amount']);
+        $money->setAmount($this->getFloatValueForAmount($details));
         return $result;
     }
 
@@ -227,7 +227,7 @@ final class MT942Normalizer extends MT942Formatter
         }
         $result->setEntryDate(!empty($details[0]['entry_date']) ? $details[0]['entry_date'] : null);
         $result->setMark($details[0]['mark']);
-        $result->setAmount((float)$details[0]['amount']);
+        $result->setAmount($this->getFloatValueForAmount($details));
         $result->setTransactionTypeIdCode($details[0]['transaction_type_id_code']);
         $result->setCustomerRef($details[0]['customer_ref']);
         return $result;
@@ -275,7 +275,19 @@ final class MT942Normalizer extends MT942Formatter
         $result->setEntriesNr(!empty($details[0]['entries_nr']) ? $details[0]['entries_nr'] : null);
         $money = $result->getMoney();
         $money->setCurrency($details[0]['currency']);
-        $money->setAmount((float)$details[0]['amount']);
+        $money->setAmount($this->getFloatValueForAmount($details));
         return $result;
     }
+	
+	/**
+     * Parse amount value as string. Replace comma by dot in order to get correct float value
+     *
+     * @param array $details.
+     *
+     * @return float
+     */
+    private function getFloatValueForAmount(array $details): float 
+	{
+		return (float) str_replace(',', '.', $details[0]['amount']);
+	}
 }


### PR DESCRIPTION
Hello Andrew,

thank you again for your work !
I'm now using this repo to parse mt942 files and I've noticed a little bug regarding float value conversions :
the decimal separator in mt942 is a comma, then parsing the value like that removes the decimal part of the ammount.
This fix replaces the comma by a dot, ensuring the correct decimal value

Cheers