### PR TITLE
Fix bug with statement information line regex

### DIFF
--- a/src/MT942Normalizer.php
+++ b/src/MT942Normalizer.php
@@ -244,7 +244,7 @@ final class MT942Normalizer extends MT942Formatter
     private function normalizeStatementInformation(string $str): StatementInformation
     {
         preg_match_all(
-            '/(?<id_code>[^?]{3})(\?(?<nr>\d\d)(?<line>[^\?]*))/s',
+            '/(?<id_code>[^?]{3})?(\?(?<nr>\d\d)(?<line>[^\?]*))/s',
             $str,
             $details,
             PREG_SET_ORDER


### PR DESCRIPTION
Hello Andrew,

here is a little fix in order to parse correctly transaction statement line information.
The group id_code is at start of the string and is never repeated.

Cheers,

Geoffroy